### PR TITLE
59 global reset

### DIFF
--- a/app/components/toolbarSearch/Search.spec.js
+++ b/app/components/toolbarSearch/Search.spec.js
@@ -1,9 +1,9 @@
 describe( 'SearchDirective', function() {
-    var $scope, scope, rootScope, HeatMapSourceGeneratorService, MapService, InfoService, element, compiledElement;
+    var $scope, scope, rootScope, HeatMapSourceGeneratorService, MapService, InfoService, element, compiledElement, searchFilter;
 
     beforeEach( module( 'SolrHeatmapApp' ) );
 
-    beforeEach( inject( function($compile, $controller, $rootScope, _HeatMapSourceGenerator_, _Map_, _InfoService_) {
+    beforeEach( inject( function($compile, $controller, $rootScope, _HeatMapSourceGenerator_, _Map_, _InfoService_, _searchFilter_) {
         rootScope = $rootScope;
         $scope = $rootScope.$new();
 
@@ -15,6 +15,7 @@ describe( 'SearchDirective', function() {
         HeatMapSourceGeneratorService = _HeatMapSourceGenerator_;
         MapService = _Map_;
         InfoService = _InfoService_;
+        searchFilter = _searchFilter_;
     }));
     it( 'searchInput is empty string', function() {
         expect(scope.filter.text).toEqual(null);
@@ -36,22 +37,25 @@ describe( 'SearchDirective', function() {
             });
         });
     });
-    describe('#resetSearchInput', function() {
-        var searchSpy, mapSpy;
+    describe('#reset', function() {
+        var searchSpy, mapSpy, filterSpy;
         beforeEach(function() {
             searchSpy = spyOn(HeatMapSourceGeneratorService, 'search');
             mapSpy = spyOn(MapService, 'resetMap');
+            filterSpy = spyOn(searchFilter, 'resetFilter');
             scope.searchInput = 'San Diego';
         });
-        describe('calls search on HeatMapSourceGeneratorService', function() {
-            it('once', function() {
-                scope.resetSearchInput();
-                expect(searchSpy).toHaveBeenCalledTimes(1);
-            });
-            it('with searchInput', function() {
-                scope.resetSearchInput();
-                expect(searchSpy).toHaveBeenCalledWith('');
-            });
+        it('calls search on HeatMapSourceGeneratorService once', function() {
+            scope.reset();
+            expect(searchSpy).toHaveBeenCalledTimes(1);
+        });
+        it('calls restMap on MapService once', function() {
+            scope.reset();
+            expect(mapSpy).toHaveBeenCalledTimes(1);
+        });
+        it('calls resetFilter on searchFilter once', function() {
+            scope.reset();
+            expect(filterSpy).toHaveBeenCalledTimes(1);
         });
     });
     describe('#onKeyPress', function() {

--- a/app/components/toolbarSearch/toolbarSearchDirective.js
+++ b/app/components/toolbarSearch/toolbarSearchDirective.js
@@ -54,15 +54,11 @@
                     HeatMapSourceGenerator.search(vm.filter.text);
                 };
 
-                vm.resetSearchInput = function() {
-                    vm.filter.text = '';
-                    HeatMapSourceGenerator.search(vm.filter.text);
-
+                vm.reset = function() {
+                    searchFilter.resetFilter();
+                    HeatMapSourceGenerator.search();
                     // Reset the map
                     MapService.resetMap();
-
-                    // Reset the date fields
-                    //ToDo: Reset date fields
                 };
 
                 vm.showtoolbarSearchInfo = function() {

--- a/app/components/toolbarSearch/toolbarSearchField.tpl.html
+++ b/app/components/toolbarSearch/toolbarSearchField.tpl.html
@@ -10,7 +10,7 @@
 </div>
 <div class="col-xs-2 padding-search">
     <span class="searchbtn">
-        <button class="btn btn-primary btn-sm" type="button" ng-click="resetSearchInput()">Reset</button>
+        <button class="btn btn-primary btn-sm" type="button" ng-click="reset()">Reset</button>
     </span>
 
     <span class="searchbtn">

--- a/app/service/searchFilter.js
+++ b/app/service/searchFilter.js
@@ -34,6 +34,12 @@
                 service.hm = MapService.getReducedQueryFromExtent(filter.geo);
             }
         };
+        service.resetFilter = function() {
+            service.time = null;
+            service.text = null;
+            service.user = null;
+            service.geo = '[-90,-180 TO 90,180]';
+        };
         return service;
     }]);
 })();

--- a/tests/service/searchFilter.spec.js
+++ b/tests/service/searchFilter.spec.js
@@ -30,4 +30,21 @@ describe( 'searchFilter', function() {
             expect(subject.geo).toEqual('[2,1 TO 2,1]');
         });
     });
+    describe('#resetFilter', function() {
+        it('resets the user', function() {
+            subject.setFilter({user: 'Diego'});
+            subject.resetFilter();
+            expect(subject.user).toEqual(null);
+        });
+        it('resets the text', function() {
+            subject.setFilter({text: 'San Diego'});
+            subject.resetFilter();
+            expect(subject.text).toEqual(null);
+        });
+        it('resets the geo', function() {
+            subject.setFilter({geo: '[2,1 TO 2,1]'});
+            subject.resetFilter();
+            expect(subject.geo).toEqual('[-90,-180 TO 90,180]');
+        });
+    });
 });


### PR DESCRIPTION
## What does this PR do?

Adds a global reset for the search filter. 
can be used with the searchFilter service. 
resets all the filters to their original.
### Related Issue
#59
- [ ] the reset buttons needs to be moved accordingly
